### PR TITLE
Bandaid fix for alloc_matmul on julia 0.5

### DIFF
--- a/src/AxisAlgorithms.jl
+++ b/src/AxisAlgorithms.jl
@@ -37,7 +37,7 @@ A_mul_B_perm(M::AbstractMatrix, src, dim::Integer) = A_mul_B_perm!(alloc_matmul(
 function alloc_matmul{S,N}(M,src::AbstractArray{S,N},dim)
     sz = [size(src)...]
     sz[dim] = size(M,1)
-    T = Base.promote_op(Base.MulFun, eltype(M), S)
+    T = Base.promote_op(Base.MulFun(), eltype(M), S)
     Array(T, sz...)::Array{T,N}
 end
 


### PR DESCRIPTION
Since `MulFun` was deprecated it has become `Base.#*` on julia master.
This fixes the following error (which I encountered because it is breaking `Interpolations`):

```
julia> Base.promote_op(Base.MulFun, Float64, Float64)
WARNING: Base.MulFun is deprecated, use Base.#* instead.
  likely near no file:0
ERROR: MethodError: no method matching Base.#*(::Float64, ::Float64)
Closest candidates are:
  Base.#*{T}(::Any) at sysimg.jl:53
 in promote_op(::Type{T}, ::Type{Float64}, ::Type{Float64}) at ./number.jl:73
```

Of course, it still gives deprecation warnings, but I'm not sure how to fix that:

```
julia> Base.promote_op(Base.MulFun(), Float64, Float64)
WARNING: Base.MulFun is deprecated, use Base.#* instead.
  likely near no file:0

WARNING: Base.MulFun is deprecated, use Base.#* instead.
  likely near no file:0
Float64
```

This form also works on 0.4.
