### PR TITLE
Fix error on Julia 0.5 due to MulFun deprecation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.4-
 WoodburyMatrices
+Compat 0.8

--- a/src/AxisAlgorithms.jl
+++ b/src/AxisAlgorithms.jl
@@ -3,6 +3,7 @@ isdefined(Base, :__precompile__) && __precompile__()
 module AxisAlgorithms
 
 using WoodburyMatrices
+using Compat
 
 export A_ldiv_B_md!,
     A_ldiv_B_md,
@@ -37,7 +38,7 @@ A_mul_B_perm(M::AbstractMatrix, src, dim::Integer) = A_mul_B_perm!(alloc_matmul(
 function alloc_matmul{S,N}(M,src::AbstractArray{S,N},dim)
     sz = [size(src)...]
     sz[dim] = size(M,1)
-    T = Base.promote_op(Base.MulFun, eltype(M), S)
+    T = Base.promote_op(@functorize(*), eltype(M), S) # functorize macro used to support julia 0.4
     Array(T, sz...)::Array{T,N}
 end
 


### PR DESCRIPTION
This should hopefully solve the issue that was addressed in #1, except properly this time.
It introduces a dependency on Compat.

As it is said in the other PR, the error breaks `Interpolations`. So if this is merged, I think the fix should grant a new tagged version. Furthermore, all other versions should get an upper bound on julia at version `0.5.0-dev+3701` (I think) in METADATA.
It may also be a good idea to set the minimum at `0.4` now, rather than `0.4-`.
