### PR TITLE
Fixed alloc_matmul to handle more than 3 dimensions.

### DIFF
--- a/src/AxisAlgorithms.jl
+++ b/src/AxisAlgorithms.jl
@@ -39,7 +39,7 @@ function alloc_matmul{S,N}(M,src::AbstractArray{S,N},dim)
     sz = [size(src)...]
     sz[dim] = size(M,1)
     T = Base.promote_op(@functorize(*), eltype(M), S) # functorize macro used to support julia 0.4
-    VERSION < v"0.5.0" ? Array{T}(sz...) : Array{T,N}(sz...)
+    VERSION < v"0.5.0" ? Array{T}((sz...)) : Array{T,N}((sz...))
 end
 
 include("tridiag.jl")

--- a/test/woodbury.jl
+++ b/test/woodbury.jl
@@ -12,8 +12,8 @@ W = Woodbury(F, U, C, V)
 
 src = rand(5, 8)
 @test W\src ≈ AxisAlgorithms.A_ldiv_B_md(W, src, 1)
-src = rand(5, 5, 5)
-for dim = 1:3
+src = rand((5, 5, 5, 5))
+for dim = 1:4
     dest1 = mapslices(x->W\x, copy(src), dim)
     dest2 = similar(src)
     AxisAlgorithms.A_ldiv_B_md!(dest2, W, src, dim)


### PR DESCRIPTION
Simple issue with the way Julia allocates arrays of higher dimension.  Did this to fix #151 on JuliaMath/Interpolations.jl.

My first pull request (ever), so if I've broken any official or unofficial rules of contributing, I'd be appreciative if you let me know.