### PR TITLE
size->axes in tridiag

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisAlgorithms"
 uuid = "13072b0f-2c55-5437-9ae7-d433b7a33950"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -10,11 +10,12 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 WoodburyMatrices = "efce3f68-66dc-5838-9240-27a6d6f5f9b6"
 
 [compat]
-WoodburyMatrices = "0.4.1, 0.5"
+WoodburyMatrices = "0.5.4"
 julia = "1"
 
 [extras]
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["OffsetArrays", "Test"]

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -1,11 +1,3 @@
-@static if VERSION < v"0.7.0-DEV.481"
-    const _mul! = isdefined(:mul!) ? mul! : Base.A_mul_B!
-    const _mul2! = isdefined(:mul!) ? mul! : Base.scale!
-else
-    const _mul! = (@isdefined mul!) ? mul! : Base.A_mul_B!
-    const _mul2! = (@isdefined mul!) ? mul! : scale.A_mul_B!
-end
-
 # Consider permutedims as an alternative to direct multiplication.
 # Multiplication is an O(m*N) cost compared to an O(N) cost for tridiagonal algorithms.
 # However, when the multiplication is only a small fraction of the total time
@@ -23,7 +15,7 @@ function A_mul_B_perm!(dest, M::AbstractMatrix, src, dim::Integer)
     order = [dim; setdiff(1:ndims(src), dim)]
     srcp = permutedims(src, order)
     tmp = Array{eltype(dest), 2}(undef, size(dest, dim), div(length(dest), size(dest, dim)))
-    _mul!(tmp, M, reshape(srcp, (size(src,dim), div(length(srcp), size(src,dim)))))
+    mul!(tmp, M, reshape(srcp, (size(src,dim), div(length(srcp), size(src,dim)))))
     iorder = [2:dim; 1; dim+1:ndims(src)]
     permutedims!(dest, reshape(tmp, size(dest)[order]), iorder)
     dest
@@ -37,7 +29,7 @@ storing the result in `dest`. `M` must be an `AbstractMatrix`. This uses an in-p
 function A_mul_B_md!(dest, M::AbstractMatrix, src, dim::Integer)
     check_matmul_sizes(dest, M, src, dim)
     if size(M,1) == size(M,2) == 1
-        return _mul2!(dest, src, M[1,1])
+        return mul!(dest, src, M[1,1])
     end
     R2 = CartesianIndices(size(dest)[dim+1:end])
     if dim > 1

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -1,52 +1,57 @@
-n = 5
-m = 3
-src = rand(n,n,n)
-for M in (rand(m,n), sprand(m,n,0.2))
-    for dim = 1:3
-        dest1 = mapslices(b->M*b, src, dims=dim)
-        sz = fill(n,3)
-        sz[dim] = m
-        dest2 = rand(sz...)
-        AxisAlgorithms.A_mul_B_md!(dest2, M, src, dim)
-        @test dest1 ≈ dest2
-        if !issparse(M)
-            rand!(dest2)
-            AxisAlgorithms.A_mul_B_perm!(dest2, M, src, dim)
+using AxisAlgorithms
+using Test
+
+@testset "matmul" begin
+    n = 5
+    m = 3
+    src = rand(n,n,n)
+    for M in (rand(m,n), sprand(m,n,0.2))
+        for dim = 1:3
+            dest1 = mapslices(b->M*b, src, dims=dim)
+            sz = fill(n,3)
+            sz[dim] = m
+            dest2 = rand(sz...)
+            AxisAlgorithms.A_mul_B_md!(dest2, M, src, dim)
             @test dest1 ≈ dest2
+            if !issparse(M)
+                rand!(dest2)
+                AxisAlgorithms.A_mul_B_perm!(dest2, M, src, dim)
+                @test dest1 ≈ dest2
+            end
         end
     end
-end
 
-# Test size-checking
-for dim = 1:3
-    M = sprand(m,n,0.2)
-    dest1 = mapslices(b->M*b, src, dims=dim)
-    sz = fill(n,3)
-    sz[dim] = m+1
-    dest2 = rand(sz...)
-    @test_throws DimensionMismatch AxisAlgorithms.A_mul_B_md!(dest2, M, src, dim)
-    @test_throws DimensionMismatch AxisAlgorithms.A_mul_B_perm!(dest2, M, src, dim)
-    sz[dim] = m
-    sz[mod1(dim+1,3)] = 1
-    dest2 = rand(sz...)
-    @test_throws DimensionMismatch AxisAlgorithms.A_mul_B_md!(dest2, M, src, dim)
-    @test_throws DimensionMismatch AxisAlgorithms.A_mul_B_perm!(dest2, M, src, dim)
-end
+    # Test size-checking
+    for dim = 1:3
+        M = sprand(m,n,0.2)
+        dest1 = mapslices(b->M*b, src, dims=dim)
+        sz = fill(n,3)
+        sz[dim] = m+1
+        dest2 = rand(sz...)
+        @test_throws DimensionMismatch AxisAlgorithms.A_mul_B_md!(dest2, M, src, dim)
+        @test_throws DimensionMismatch AxisAlgorithms.A_mul_B_perm!(dest2, M, src, dim)
+        sz[dim] = m
+        sz[mod1(dim+1,3)] = 1
+        dest2 = rand(sz...)
+        @test_throws DimensionMismatch AxisAlgorithms.A_mul_B_md!(dest2, M, src, dim)
+        @test_throws DimensionMismatch AxisAlgorithms.A_mul_B_perm!(dest2, M, src, dim)
+    end
 
-# Test 1x1 and 2x2 cases
-n = 5
-for dim = 1:3
-    sz = fill(n,3)
-    sz[dim] = 1
-    src2 = rand(sz...)
-    M = fill(3.2,1,1)
-    dest1 = mapslices(b->M*b, src2, dims=dim)
-    dest2 = AxisAlgorithms.A_mul_B_md(M, src2, dim)
-    @test dest1 ≈ dest2
-    sz[dim] = 2
-    src2 = rand(sz...)
-    M = rand(2,2)
-    dest1 = mapslices(b->M*b, src2, dims=dim)
-    dest2 = AxisAlgorithms.A_mul_B_md(M, src2, dim)
-    @test dest1 ≈ dest2
+    # Test 1x1 and 2x2 cases
+    n = 5
+    for dim = 1:3
+        sz = fill(n,3)
+        sz[dim] = 1
+        src2 = rand(sz...)
+        M = fill(3.2,1,1)
+        dest1 = mapslices(b->M*b, src2, dims=dim)
+        dest2 = AxisAlgorithms.A_mul_B_md(M, src2, dim)
+        @test dest1 ≈ dest2
+        sz[dim] = 2
+        src2 = rand(sz...)
+        M = rand(2,2)
+        dest1 = mapslices(b->M*b, src2, dims=dim)
+        dest2 = AxisAlgorithms.A_mul_B_md(M, src2, dim)
+        @test dest1 ≈ dest2
+    end
 end

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -1,21 +1,22 @@
-@static if VERSION < v"0.7.0-DEV.481"
-    const _ldiv! = isdefined(:ldiv!) ? ldiv! : Base.A_ldiv_B!
-else
-    const _ldiv! = (@isdefined ldiv!) ? ldiv! : Base.A_ldiv_B!
-end
-const _lu = @static VERSION < v"0.7.0-DEV.3449" ? Base.lufact : lu
+using Test, OffsetArrays
 
-let
+@testset "Tridiag" begin
     d  = 2 .+ rand(5)
     dl = rand(4)
     du = rand(4)
     M = Tridiagonal(dl, d, du)
-    F = _lu(M)
+    F = lu(M)
     src = rand(5,5,5)
     for dim = 1:3
-        dest1 = mapslices(x->_ldiv!(F, x), copy(src), dims=dim)
+        dest1 = mapslices(x->ldiv!(F, x), copy(src), dims=dim)
         dest2 = similar(src)
         AxisAlgorithms.A_ldiv_B_md!(dest2, F, src, dim)
         @test dest1 ≈ dest2
     end
+
+    src = OffsetArray(src, -2:2, 1:5, 0:4)
+    dest1 = mapslices(x->ldiv!(F, x), copy(src), dims=2)
+    dest2 = similar(src)
+    AxisAlgorithms.A_ldiv_B_md!(dest2, F, src, 2)
+    @test dest1 ≈ dest2
 end

--- a/test/woodbury.jl
+++ b/test/woodbury.jl
@@ -1,23 +1,24 @@
 using WoodburyMatrices
+using Test
 
-const _lu = @static VERSION < v"0.7.0-DEV.3449" ? Base.lufact : lu
+@testset "Woodbury" begin
+    d  = 2 .+ rand(5)
+    dl = -rand(4)
+    du = -rand(4)
+    M = Tridiagonal(dl, d, du)
+    F = lu(M)
+    U = sprand(5,2,0.2)
+    V = sprand(2,5,0.2)
+    C = rand(2,2)
+    W = Woodbury(F, U, C, V)
 
-d  = 2 .+ rand(5)
-dl = -rand(4)
-du = -rand(4)
-M = Tridiagonal(dl, d, du)
-F = _lu(M)
-U = sprand(5,2,0.2)
-V = sprand(2,5,0.2)
-C = rand(2,2)
-W = Woodbury(F, U, C, V)
-
-src = rand(5, 8)
-@test W\src ≈ AxisAlgorithms.A_ldiv_B_md(W, src, 1)
-src = rand(5, 5, 5, 5)
-for dim = 1:4
-    dest1 = mapslices(x->W\x, copy(src), dims=dim)
-    dest2 = similar(src)
-    AxisAlgorithms.A_ldiv_B_md!(dest2, W, src, dim)
-    @test dest1 ≈ dest2
+    src = rand(5, 8)
+    @test W\src ≈ AxisAlgorithms.A_ldiv_B_md(W, src, 1)
+    src = rand(5, 5, 5, 5)
+    for dim = 1:4
+        dest1 = mapslices(x->W\x, copy(src), dims=dim)
+        dest2 = similar(src)
+        AxisAlgorithms.A_ldiv_B_md!(dest2, W, src, dim)
+        @test dest1 ≈ dest2
+    end
 end


### PR DESCRIPTION
This package was written prior to the introduction of arbitrary
indexing. This updates much of the `tridiag` component, although we
still need to extend support for the factorization.
    
Motivated by noticing https://github.com/JuliaImages/ImageTransformations.jl/blob/4d89e5cecbf115d6b25976f12ac7a32c92a5bfc0/src/interpolations.jl#L45-L55